### PR TITLE
Moving Resource observer into Resource model

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -17,9 +17,4 @@ class Plugin extends PluginBase
             'icon' => 'icon-cloud'
         ];
     }
-
-    public function boot()
-    {
-        Resource::observe(ResourceObserver::class);
-    }
 }

--- a/models/Resource.php
+++ b/models/Resource.php
@@ -11,10 +11,8 @@ use RainLab\Builder\Classes\ComponentHelper;
 class Resource extends Model
 {
     use \October\Rain\Database\Traits\Validation;
-    
-    use \October\Rain\Database\Traits\SoftDelete;
 
-    protected $dates = ['deleted_at'];
+    protected $dates = [];
 
     /**
      * @var string The database table used by the model.

--- a/models/Resource.php
+++ b/models/Resource.php
@@ -2,6 +2,7 @@
 
 namespace IPriceGroup\OcApiPlugin\Models;
 
+use IPriceGroup\OcApiPlugin\Classes\ResourceObserver;
 use Model;
 use RainLab\Builder\Classes\ComponentHelper;
 
@@ -36,5 +37,12 @@ class Resource extends Model
         unset($globalModels[self::class]);
 
         return $globalModels;
+    }
+
+    protected static function boot()
+    {
+        self::observe(ResourceObserver::class);
+
+        parent::boot();
     }
 }

--- a/updates/builder_table_create_ipricegroup_ocapiplugin_resources.php
+++ b/updates/builder_table_create_ipricegroup_ocapiplugin_resources.php
@@ -13,12 +13,13 @@ class BuilderTableCreateIpricegroupOcapipluginResources extends Migration
         {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
-            $table->string('base_endpoint')->unique();
+            $table->string('base_endpoint');
             $table->string('model_class');
             $table->json('eager_load');
             $table->boolean('is_auth_required')->default(false);
             $table->timestamp('created_at')->nullable();
             $table->timestamp('updated_at')->nullable();
+            $table->timestamp('deleted_at')->nullable();
         });
     }
     

--- a/updates/builder_table_create_ipricegroup_ocapiplugin_resources.php
+++ b/updates/builder_table_create_ipricegroup_ocapiplugin_resources.php
@@ -19,7 +19,6 @@ class BuilderTableCreateIpricegroupOcapipluginResources extends Migration
             $table->boolean('is_auth_required')->default(false);
             $table->timestamp('created_at')->nullable();
             $table->timestamp('updated_at')->nullable();
-            $table->timestamp('deleted_at')->nullable();
         });
     }
     

--- a/updates/builder_table_create_ipricegroup_ocapiplugin_resources.php
+++ b/updates/builder_table_create_ipricegroup_ocapiplugin_resources.php
@@ -13,7 +13,7 @@ class BuilderTableCreateIpricegroupOcapipluginResources extends Migration
         {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
-            $table->string('base_endpoint');
+            $table->string('base_endpoint')->unique();
             $table->string('model_class');
             $table->json('eager_load');
             $table->boolean('is_auth_required')->default(false);

--- a/updates/builder_table_update_ipricegroup_ocapiplugin_resources.php
+++ b/updates/builder_table_update_ipricegroup_ocapiplugin_resources.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace IPriceGroup\OcApiPlugin\Updates;
+
+use Schema;
+use October\Rain\Database\Updates\Migration;
+
+class BuilderTableUpdateIpricegroupOcapipluginResources extends Migration
+{
+    const TABLE_NAME = 'ipricegroup_ocapiplugin_resources';
+
+    public function up()
+    {
+        Schema::table(self::TABLE_NAME, function($table)
+        {
+            $table->unique('base_endpoint');
+            $table->dropColumn('deleted_at');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table(self::TABLE_NAME, function($table)
+        {
+            $table->dropUnique(self::TABLE_NAME . '_base_endpoint_unique');
+            $table->timestamp('deleted_at')->nullable();
+        });
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -1,3 +1,6 @@
 1.0.0:
     - 'Initialize plugin'
     - builder_table_create_ipricegroup_ocapiplugin_resources.php
+1.0.1:
+    - 'Make base_endpoint unique and remove soft delete'
+    - builder_table_update_ipricegroup_ocapiplugin_resources.php


### PR DESCRIPTION
The changes of this pull request:
- Move Resource from Plugin file into the Resource model
- Make base_endpoint to be unique
- Remove soft delete operation

Issue: #2 