### PR TITLE
Add permission to iPrice RESTful API Generator (#3)

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -17,14 +17,4 @@ class Plugin extends PluginBase
             'icon' => 'icon-cloud'
         ];
     }
-
-    public function registerPermissions()
-    {
-        return [
-            'ipricegroup.ocapiplugin.manage_apis' => [
-                'label' => 'Manage the API endpoints',
-                'tab' => 'APIs'
-            ]
-        ];
-    }
 }

--- a/Plugin.php
+++ b/Plugin.php
@@ -17,4 +17,14 @@ class Plugin extends PluginBase
             'icon' => 'icon-cloud'
         ];
     }
+
+    public function registerPermissions()
+    {
+        return [
+            'ipricegroup.ocapiplugin.manage_apis' => [
+                'label' => 'Manage the API endpoints',
+                'tab' => 'APIs'
+            ]
+        ];
+    }
 }

--- a/controllers/Resources.php
+++ b/controllers/Resources.php
@@ -13,6 +13,8 @@ class Resources extends Controller
     public $listConfig = 'config_list.yaml';
     public $formConfig = 'config_form.yaml';
 
+    public $requiredPermissions = ['ipricegroup.ocapiplugin.manage_apis'];
+
     /**
      * @var ApiGenerator
      */

--- a/controllers/Resources.php
+++ b/controllers/Resources.php
@@ -9,7 +9,7 @@ use IPriceGroup\OcApiPlugin\Classes\ApiGenerator;
 class Resources extends Controller
 {
     public $implement = [        'Backend\Behaviors\ListController',        'Backend\Behaviors\FormController'    ];
-    
+
     public $listConfig = 'config_list.yaml';
     public $formConfig = 'config_form.yaml';
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -11,7 +11,3 @@ navigation:
         icon: icon-cloud
         permissions:
             - manage_apis
-permissions:
-    manage_apis:
-        tab: 'Manage APIs'
-        label: 'Manage APIs'

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -10,7 +10,7 @@ navigation:
         url: /ipricegroup/ocapiplugin/resources
         icon: icon-cloud
         permissions:
-        - iprice-restful-api-generator
+            - iprice-restful-api-generator
 permissions:
     iprice-restful-api-generator:
         tab: 'IPrice RESTful API Generator'

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -9,3 +9,9 @@ navigation:
         label: 'iPrice API'
         url: /ipricegroup/ocapiplugin/resources
         icon: icon-cloud
+        permissions:
+        - iprice-restful-api-generator
+permissions:
+    iprice-restful-api-generator:
+        tab: 'IPrice RESTful API Generator'
+        label: 'Manage IPrice RESTful API Generator'

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -11,3 +11,7 @@ navigation:
         icon: icon-cloud
         permissions:
             - manage_apis
+permissions:
+    manage_apis:
+        tab: 'APIs'
+        label: 'Manage the API endpoints'

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -10,8 +10,8 @@ navigation:
         url: /ipricegroup/ocapiplugin/resources
         icon: icon-cloud
         permissions:
-            - iprice-restful-api-generator
+            - manage_apis
 permissions:
-    iprice-restful-api-generator:
-        tab: 'IPrice RESTful API Generator'
-        label: 'Manage IPrice RESTful API Generator'
+    manage_apis:
+        tab: 'Manage APIs'
+        label: 'Manage APIs'

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -4,3 +4,5 @@
 1.0.1:
     - 'Make base_endpoint unique and remove soft delete'
     - builder_table_update_ipricegroup_ocapiplugin_resources.php
+1.0.2:
+    - 'Register Manage APIs permission'


### PR DESCRIPTION
## Scenario:

Our plugin iPrice RESTful API Generator can be accessed by a non-admin user because there is no permission for this plugin. This pull request is to add permission for our API Generator plugin so we can restrict non-admin users to access to this plugin.